### PR TITLE
Add support for Timer type 'ms'

### DIFF
--- a/mockdog.py
+++ b/mockdog.py
@@ -10,7 +10,7 @@ logging.basicConfig(format='%(asctime)s %(message)s',
 logger = logging.getLogger(__name__)
 
 msg_format = re.compile(
-    r"(?P<name>.*?):(?P<value>.*?)\|(?P<type>[a-z])\|#(?P<tags>.*)"
+    r"(?P<name>.*?):(?P<value>.*?)\|(?P<type>[a-z]*)\|#(?P<tags>.*)"
 )
 
 '''


### PR DESCRIPTION
Valid values for type are one or two characters.
Defined types are:
 * `c` for Counter
 * `g` for Guage
 * `h` for Historgram
 * `ms` for Timer
 * `s` for Set

Metric Types are defined at: http://docs.datadoghq.com/guides/dogstatsd/#metrics-1